### PR TITLE
スクリーンショットの画面は Bleuclair テーマのものであることを注記しておく

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -14,3 +14,6 @@ RedMicaはオープンソースのプロジェクト管理ソフトウェア `Re
 
    about-redmica
    reference/index
+
+.. note::
+   リファレンス中のスクリーンショットは `Bleuclair <https://github.com/farend/redmine_theme_farend_bleuclair>`_ テーマのものです。


### PR DESCRIPTION
RedMica 4.0 で、それまで同梱していた Bleuclair が削除され、初期テーマもデフォルトテーマに変更された。混乱を避けるため、リファレンス中のスクリーンショットは Bleuclair テーマを使っていることをトップページで一言補足しておく。

<img width="1243" height="1927" alt="CleanShot 2026-01-14 at 12 19 57" src="https://github.com/user-attachments/assets/206434d9-43fe-4f46-ab58-579f3dc629cb" />
